### PR TITLE
WIP: deployment overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Includes:
+
+# Excludes:
 *.retry
 hosts-deploy.yaml
+files/bootkube
+files/backup/bootkube
 roles/deploy-kubelet/templates/kubeconfig

--- a/README.md
+++ b/README.md
@@ -1,3 +1,33 @@
+# Playbook Ordering:
+1. Clean previous bootstrap deployment if bootstrap_enabled=true
+2. Prepare the bootkube host
+2. Render assets | or | BYOA folder (copy bootkube folder to `files` directory)
+3. Download CNI requirements
+4. Deploy Kubelet (will be in wait state until API server is available)
+5. Sync bootkube directory in /tmp/bootkube (on remote hosts)
+5. Load declared sdn cni plugins
+6. Launch bootkube
+
+
+
+## Rendering Assets
+Promenade is flexible, and allows operators to generate their own rendered assets if they wish. To that this point, there are two methods for implementing rendered assets with Promenade. You can either render assets on your own locally (on your own host or elsewhere), and have them deployed (this is default), or you can have Promenade intelligently render assets on your behalf as part of the bootstrap process. The boolean variable `bootkube_render` is what determines the rendering actions. Using `bootkube_render=true` at the time of deployment will override the default "bring your own assets" behavior and automatically render assets for you on the bootstrap host.
+
+docker run quay.io/coreos/bootkube:v0.4.0 \
+      --insecure-options=image \
+      --volume=target,kind=host,source="${PWD}" \
+      --mount volume=target,target=/target \
+      --net=none \
+      --exec=/bootkube \
+      -- render \
+      --asset-dir=/target/assets/bootkube \
+      --api-servers=https://172.15.0.10:443 \
+      --etcd-servers=http://master.k8s:2379 \
+      --api-server-alt-names=DNS=master.k8s,IP=172.15.0.10
+
+
+
+
 # Promenade: Manually Self-hosted Kubernetes via Bootkube
 A small howto on how to bring up a self-hosted kubernetes cluster
 

--- a/files/README.md
+++ b/files/README.md
@@ -1,0 +1,2 @@
+# Files
+This is where you would include the `bootkube` directory from `bootkube render`.

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -1,0 +1,38 @@
+#Default Override-able variables for bootstrap role
+bootstrap_enabled: "false"
+ansible_user: "ubuntu"
+#ansible_ssh_pass="password"
+
+# For DNS Resilliency, override this with FQDN in your environment which resolves to all "master" servers
+api_server_fqdn: "cluster-ha.default.svc.cluster.local"
+cluster_domain: "cluster.local"
+
+# Kubernetes versions:
+boot_kube_version: "v0.4.0"
+hyperkube_version: "v1.6.1"
+kubelet_version: "v1.6.1"
+kube_controller_manager_version: "v1.6.1"
+kube_label: "openstack-control-plane"
+kube_sdn: "calico"
+kube_cluster_cidr: "10.2.0.0/16"
+kube_cluster_ip: "10.3.0.10"
+# "10.244.0.0/16"
+
+# SDN/CNI Parameters:
+cni_version: "v0.5.2"
+calico_cni_plugin_version: "v1.6.1"
+calicoctl_version: "v1.1.1"
+
+# Calico BGP Peering Options:
+calico_peer1: 10.23.21.2
+calico_peer2: 10.23.21.3
+
+## Kubernetes Add-Ons:
+# Optional Items: kube_dashboard, kube_helm (more to come).
+addons_enabled: false
+addons:
+  - dashboard
+  - helm
+  - osh
+  - ceph
+  - maas

--- a/inventories/testing/group_vars/all.yaml
+++ b/inventories/testing/group_vars/all.yaml
@@ -1,0 +1,33 @@
+#Default Override-able variables for bootstrap role
+bootstrap_enabled: "false"
+ansible_user: "ubuntu"
+#ansible_ssh_pass="password"
+
+# For DNS Resilliency, override this with FQDN in your environment which resolves to all "master" servers
+api_server_fqdn: "cluster-ha.default.svc.cluster.local"
+cluster_domain: "cluster.local"
+
+# Kubernetes versions:
+boot_kube_version: "v0.4.0"
+hyperkube_version: "v1.6.1"
+kubelet_version: "v1.6.1"
+kube_controller_manager_version: "v1.6.1"
+kube_label: "openstack-control-plane"
+
+# SDN/CNI Parameters:
+cni_version: "v0.5.2"
+calicoctl_version: "v1.1.1"
+
+# Calico BGP Peering Options:
+calico_peer1: 10.23.21.2
+calico_peer2: 10.23.21.3
+
+## Kubernetes Add-Ons:
+# Optional Items: kube_dashboard, kube_helm (more to come).
+addons_enabled: false
+addons:
+  - dashboard
+  - helm
+  - osh
+  - ceph
+  - maas

--- a/inventories/testing/host_vars/host-template.yaml
+++ b/inventories/testing/host_vars/host-template.yaml
@@ -1,0 +1,4 @@
+##  Role:
+#   Options: master, worker
+#   Note: More grainular options coming soon (api, controller, etc)
+kube_role: master

--- a/inventories/testing/host_vars/kubenode01.yaml
+++ b/inventories/testing/host_vars/kubenode01.yaml
@@ -1,0 +1,6 @@
+##  Role:
+#   Options: master, worker
+#   Note: More grainular options coming soon (api, controller, etc)
+kube_role: master
+
+hostname: kubenode01

--- a/inventories/testing/host_vars/kubenode02.yaml
+++ b/inventories/testing/host_vars/kubenode02.yaml
@@ -1,0 +1,6 @@
+##  Role:
+#   Options: master, worker
+#   Note: More grainular options coming soon (api, controller, etc)
+kube_role: worker
+
+hostname: kubenode02

--- a/inventories/testing/host_vars/kubenode03.yaml
+++ b/inventories/testing/host_vars/kubenode03.yaml
@@ -1,0 +1,6 @@
+##  Role:
+#   Options: master, worker
+#   Note: More grainular options coming soon (api, controller, etc)
+kube_role: worker
+
+hostname: kubenode03

--- a/inventory.ini
+++ b/inventory.ini
@@ -1,0 +1,38 @@
+#Sample Hosts File with variables
+
+#For Single node deployments, make sure that the bootstrap node is listed as a master and worker node as well.
+[bootstrap]
+192.168.4.64
+
+[master]
+#Make sure bootstrap node is first master node
+192.168.4.64
+
+[workers]
+192.168.4.79
+192.168.4.80
+192.168.4.58
+
+
+[bootstrap:vars]
+node_master=true
+
+
+
+[master:vars]
+node_master=true
+calico_peer1="192.168.0.4"
+calico_peer2="192.168.0.5"
+deploy_pods_master=true
+
+[all:vars]
+#ansible_user="ubuntu"
+#ansible_ssh_pass="password"
+#API Server FQDN is required for SkyDNS to resolve
+#api_server_fqdn="cluster-ha.default.svc.cluster.local"
+#cluster_domain="cluster.local"
+#cni_version="v0.5.1"
+#hyperkube_version="v1.5.6"
+#kubelet_version="v1.5.6"
+#kube_labels="openstack-control-plane"
+#kube_controller_manager_version="v1.5.6"

--- a/promenade
+++ b/promenade
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+inventory=${INVENTORY:-inventory.ini}
+
+ansible-playbook -i ${inventory} site.yaml $@ 

--- a/roles/deploy-bootkube/main.yaml
+++ b/roles/deploy-bootkube/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: restart kubelet
+  service: name=kubelet state=restarted

--- a/roles/deploy-bootkube/tasks/deploy-bootkube.yaml
+++ b/roles/deploy-bootkube/tasks/deploy-bootkube.yaml
@@ -1,0 +1,13 @@
+---
+- name: Setup bootkube.service
+  when: bootstrap_enabled
+  template:
+    src: bootkube.service.j2
+    dest: /etc/systemd/system/bootkube.service
+
+- name: Run bootkube
+  when: bootstrap_enabled
+  systemd:
+    name: bootkube
+    state: started
+    daemon_reload: yes

--- a/roles/deploy-bootkube/tasks/deploy-hyperkube.yaml
+++ b/roles/deploy-bootkube/tasks/deploy-hyperkube.yaml
@@ -1,0 +1,10 @@
+---
+- name: Download the Hyperkube binary
+  get_url:
+    url: "http://storage.googleapis.com/kubernetes-release/release/{{ hyperkube_version }}/bin/linux/amd64/hyperkube"
+    dest: /usr/local/bin/hyperkube
+
+- name: Set hyperkube permissions
+  file:
+    path: /usr/local/bin/hyperkube
+    mode: 0755

--- a/roles/deploy-bootkube/tasks/deploy-kube-manifests.yaml
+++ b/roles/deploy-bootkube/tasks/deploy-kube-manifests.yaml
@@ -1,0 +1,22 @@
+---
+# Obtains auth/kubeconfig from loaded bootkube assets
+- name: Ensure pre-generated bootkube assets exist on the bootstrap master
+  when:
+    - (bootstrap_enabled == 'true') and (bootkube_render == 'false') and (inventory_hostname in groups['master'])
+  copy:
+    src: '../files/bootkube'
+    dest: '/tmp'
+    owner: root
+    group: root
+    mode: 0644
+
+# Obtains auth/kubeconfig from created bootkube assets
+- name: Ensure promenade-generated bootkube assets exist on the bootstrap master
+  when:
+    - (bootstrap_enabled == 'true') and (bootkube_render == 'true') and (inventory_hostname in groups['master'])
+  copy:
+    src: '../files/backup/bootkube'
+    dest: '/tmp'
+    owner: root
+    group: root
+    mode: 0644

--- a/roles/deploy-bootkube/tasks/main.yaml
+++ b/roles/deploy-bootkube/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- include: deploy-kube-manifests.yaml
+- include: deploy-hyperkube.yaml
+- include: deploy-bootkube.yaml

--- a/roles/deploy-bootkube/tasks/prep-kubernetes.yaml
+++ b/roles/deploy-bootkube/tasks/prep-kubernetes.yaml
@@ -1,0 +1,29 @@
+---
+- name: Ensures /etc/kubernetes dir exists
+  when:
+    bootstrap_enabled
+  file:
+    path: /etc/kubernetes
+    state: directory
+
+- name: copy kubeconfig credentials
+  when:
+    bootstrap_enabled
+  command: cp /tmp/bootkube/assets/auth/kubeconfig /etc/kubernetes/kubeconfig
+  args:
+    creates: /etc/kubernetes/kubeconfig
+
+- name: copy kubernetes manifests
+  when:
+    bootstrap_enabled
+  command: cp -a /tmp/bootkube/assets/manifests /etc/kubernetes/
+  args:
+    creates: /etc/kubernetes/manifests
+
+- name: fetch kubeconfig
+  when:
+    bootstrap_enabled
+  fetch:
+    src: /etc/kubernetes/kubeconfig
+    dest: roles/deploy-kubelet/templates/kubeconfig
+    flat: yes

--- a/roles/deploy-bootkube/tasks/prep-network.yaml
+++ b/roles/deploy-bootkube/tasks/prep-network.yaml
@@ -1,0 +1,14 @@
+---
+- name: Inject Custom manifests - kube-calico.yaml
+  when:
+    bootstrap_enabled
+  template:
+    src: kube-calico.yaml.j2
+    dest: "/tmp/bootkube/assets/manifests/kube-flannel.yaml"
+
+- name: Inject Custom manifests - kube-calico-cfg.yaml
+  when:
+    bootstrap_enabled
+  template:
+    src: kube-calico-cfg.yaml.j2
+    dest: "/tmp/bootkube/assets/manifests/kube-flannel-cfg.yaml"

--- a/roles/deploy-bootkube/templates/bootkube.service.j2
+++ b/roles/deploy-bootkube/templates/bootkube.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Kubernetes Control Plane Bootstrapping
+Documentation=https://github.com/kubernetes-incubator/bootkube
+
+[Service]
+ExecStart=/usr/local/bin/bootkube start --asset-dir=/tmp/bootkube/assets/
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/deploy-kubelet/tasks/deploy-kubelet.yaml
+++ b/roles/deploy-kubelet/tasks/deploy-kubelet.yaml
@@ -1,0 +1,31 @@
+---
+# TODO: Version kubelet, with checksum
+- name: Download and install the kubelet binary
+  get_url:
+    url: "http://storage.googleapis.com/kubernetes-release/release/{{ kubelet_version }}/bin/linux/amd64/kubelet"
+    dest: /usr/local/bin/kubelet
+#    checksum: md5:33af080e876b1f3d481b0ff1ceec3ab8
+    mode: 0755
+
+# Service for a master kubelet
+- name: Load and start/restart the kubelet.service for the master
+  when: inventory_hostname in groups['master']
+  template:
+    src: kubelet.service.j2
+    dest: /etc/systemd/system/kubelet.service
+  notify: restart kubelet
+
+# Service for a worker kubelet
+- name: Load and start/restart the kubelet.service for the workers
+  when: inventory_hostname in groups['workers']
+  template:
+    src: kubelet.service.j2
+    dest: /etc/systemd/system/kubelet.service
+  notify: restart kubelet
+
+- name: Enable the kubelet.service to be started on boot
+  systemd:
+    name: kubelet
+    state: restarted
+    enabled: yes
+    daemon_reload: yes

--- a/roles/deploy-kubelet/tasks/main.yaml
+++ b/roles/deploy-kubelet/tasks/main.yaml
@@ -1,6 +1,3 @@
-#Deploys Kubelet
 ---
-- include: prep-host.yaml
-- include: prep-hyperkube.yaml
-- include: prep-cni.yaml
-- include: deploy-kubernetes.yaml
+- include: prep-kubelet.yaml
+- include: deploy-kubelet.yaml

--- a/roles/deploy-kubelet/tasks/prep-kubelet.yaml
+++ b/roles/deploy-kubelet/tasks/prep-kubelet.yaml
@@ -1,0 +1,41 @@
+---
+- name: Install base packages
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "docker.io"
+    - "vim"
+    - "ethtool"
+    - "traceroute"
+    - "git"
+    - "build-essential"
+    - "lldpd"
+
+- name: Insert Temporary Hosts File Entry for FQDN Resolution
+  lineinfile:
+    dest: /etc/hosts
+    line: "{{ hostvars[groups['master'][0]]['ansible_default_ipv4']['address'] }} {{ api_server_fqdn }}"
+    state: present
+
+# Obtains auth/kubeconfig from loaded bootkube assets
+- name: Install kubeconfig from pre-generated assets
+  when:
+    - (bootstrap_enabled == 'true') and (bootkube_render == 'false')
+  copy:
+    src: '../files/bootkube/assets/auth/kubeconfig'
+    dest: '/etc/kubernetes/kubeconfig'
+    owner: root
+    group: root
+    mode: 0644
+
+# Obtains auth/kubeconfig from created bootkube assets
+- name: Install kubeconfig from promenade-generated assets
+  when:
+    - (bootstrap_enabled == 'true') and (bootkube_render == 'true')
+  copy:
+    src: '../files/backup/bootkube/assets/auth/kubeconfig'
+    dest: '/etc/kubernetes/kubeconfig'
+    owner: root
+    group: root
+    mode: 0644

--- a/roles/deploy-kubelet/templates/kubelet.service.j2
+++ b/roles/deploy-kubelet/templates/kubelet.service.j2
@@ -1,0 +1,27 @@
+[Unit]
+Description=Kubernetes Kubelet
+Documentation=https://kubernetes.io/docs/admin/kubelet/
+
+[Service]
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+ExecStart=/usr/local/bin/kubelet \
+    --kubeconfig=/etc/kubernetes/kubeconfig \
+    --require-kubeconfig \
+    --cni-conf-dir=/etc/cni/net.d \
+    --cni-bin-dir=/opt/cni/bin \
+    --network-plugin=cni \
+    --lock-file=/var/run/lock/kubelet.lock \
+    --exit-on-lock-contention \
+    --pod-manifest-path=/etc/kubernetes/manifests \
+    --allow-privileged \
+    --minimum-container-ttl-duration=6m0s \
+    --cluster_dns=10.3.0.10 \
+    --cluster_domain={{ cluster_domain }} \
+    --node-labels=master={{ node_master|default('false') }} \
+    --hostname-override={{ inventory_hostname }} \
+    --v=2
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/deploy-kubelet/templates/master-kubelet.service.j2
+++ b/roles/deploy-kubelet/templates/master-kubelet.service.j2
@@ -1,0 +1,28 @@
+[Unit]
+Description=Kubernetes Kubelet
+Documentation=https://kubernetes.io/docs/admin/kubelet/
+
+[Service]
+ExecStartPre=/bin/mkdir -p /etc/kubernetes/manifests
+ExecStart=/usr/local/bin/kubelet \
+    --kubeconfig=/etc/kubernetes/kubeconfig \
+    --require-kubeconfig \
+    --register-schedulable=false \
+    --cni-conf-dir=/etc/cni/net.d \
+    --cni-bin-dir=/opt/cni/bin \
+    --network-plugin=cni \
+    --lock-file=/var/run/lock/kubelet.lock \
+    --exit-on-lock-contention \
+    --pod-manifest-path=/etc/kubernetes/manifests \
+    --allow-privileged \
+    --minimum-container-ttl-duration=6m0s \
+    --cluster_dns=10.3.0.10 \
+    --cluster_domain={{ cluster_domain }} \
+    --node-labels=master={{ node_master|default('false') }} \
+    --hostname-override={{ inventory_hostname }} \
+    --v=2
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/prep-bootstrap-cleanup/handlers/main.yaml
+++ b/roles/prep-bootstrap-cleanup/handlers/main.yaml
@@ -1,0 +1,3 @@
+---
+- name: restart kubelet
+  service: name=kubelet state=stopped

--- a/roles/prep-bootstrap-cleanup/tasks/main.yaml
+++ b/roles/prep-bootstrap-cleanup/tasks/main.yaml
@@ -1,0 +1,2 @@
+---
+- include: prep-bootstrap-cleanup.yaml

--- a/roles/prep-bootstrap-cleanup/tasks/prep-bootstrap-cleanup.yaml
+++ b/roles/prep-bootstrap-cleanup/tasks/prep-bootstrap-cleanup.yaml
@@ -1,0 +1,72 @@
+---
+- name: If bootstrap_enabled is true, stop the Kubelet service
+  when:
+    (bootstrap_enabled)
+  systemd:
+    name: kubelet.service
+    state: stopped
+    enabled: no
+  ignore_errors: true
+
+- name: If bootstrap_enabled is true, stop the bootkube service
+  when:
+    (bootstrap_enabled) and (inventory_hostname in groups['master'])
+  systemd:
+    name: bootkube
+    state: stopped
+    enabled: no
+    daemon_reload: yes
+
+- name: If bootstrap_enabled is true, flush the bootkube directory
+  when:
+    (bootstrap_enabled) and (inventory_hostname in groups['master'])
+  file:
+    path: /tmp/bootkube
+    state: absent
+
+- name: If bootstrap_enabled is true, flush the CNI directory
+  when:
+    bootstrap_enabled
+  file:
+    path: /opt/cni
+    state: absent
+
+- name: If bootstrap_enabled is true, flush the /etc/cni configs
+  when:
+    bootstrap_enabled
+  file:
+    path: /etc/cni
+    state: absent
+
+- name: If bootstrap_enabled is true, flush the Kubernetes directory
+  when:
+    bootstrap_enabled
+  file:
+    path: /etc/kubernetes
+    state: absent
+
+- name: If bootstrap_enabled is true, flush deployed binaries
+  when:
+    bootstrap_enabled
+  file:
+    path: /usr/local/bin/{{ item }}
+    state: absent
+  with_items:
+    - kubelet
+    - hyperkube
+    - bootkube
+    - checkpoint
+
+- name: Stop all remaining bootkube and kubernetes docker artifacts
+  when:
+    bootstrap_enabled
+  shell: docker stop $(docker ps -a | grep k8s| cut -c1-20 | xargs docker stop)
+  no_log: true
+  ignore_errors: yes
+
+- name: Remove all remaining bootkube and kubernetes docker artifacts
+  when:
+    bootstrap_enabled
+  shell: docker rm $(docker ps -a | grep k8s| cut -c1-20 | xargs docker stop)
+  no_log: true
+  ignore_errors: yes

--- a/roles/prep-bootstrap-cni/tasks/deploy-calico.yaml
+++ b/roles/prep-bootstrap-cni/tasks/deploy-calico.yaml
@@ -1,0 +1,53 @@
+---
+- name: Download Calico CNI plugin
+  when:
+    - (bootstrap_enabled == 'true') and (kube_sdn == 'calico')
+  get_url:
+    url: "https://github.com/projectcalico/cni-plugin/releases/download/{{ calico_cni_plugin_version }}/calico"
+    dest: /opt/cni/bin/calico
+    owner: root
+    group: root
+    mode: 0655
+
+- name: Download Calico IPAM CNI plugin
+  when:
+    - (bootstrap_enabled == 'true') and (kube_sdn == 'calico')
+  get_url:
+    url: "https://github.com/projectcalico/cni-plugin/releases/download/{{ calico_cni_plugin_version }}/calico-ipam"
+    dest: /opt/cni/bin/calico-ipam
+    owner: root
+    group: root
+    mode: 0655
+
+- name: Download calicoctl client
+  when:
+    - (bootstrap_enabled == 'true') and (kube_sdn == 'calico') and (inventory_hostname in groups['master'])
+  get_url:
+    url: "https://github.com/projectcalico/calicoctl/releases/download/{{ calicoctl_version }}/calicoctl"
+    dest: /usr/local/bin/calicoctl
+    owner: root
+    group: root
+    mode: 0655
+
+- name: If upload the Calico CNI config to the /etc/cni/net.d directory
+  when:
+    - (bootstrap_enabled == 'true') and (kube_sdn == 'calico')
+  template:
+    src: calico-cni-config.j2
+    dest: /etc/cni/net.d/10-calico.conf
+
+#- name: If bootstrap_enabled is true, flush the /etc/cni configs
+#  when:
+#    - (bootstrap_enabled == 'true') and (kube_sdn == 'calico') and (inventory_hostname in groups['master'])
+#  template:
+#    src: calico-cni-config.j2
+#    dest: /etc/cni/net.d/10-calico.conf
+
+- name: Deploy Calico manifest to /etc/kubernetes/manifests directory
+  when:
+    - (bootstrap_enabled == 'true') and (kube_sdn == 'calico')
+  template:
+    src: calico-v1.6-manifest.yaml.j2
+    dest: /etc/kubernetes/manifests/calico.yaml
+
+# sudo ETCD_ENDPOINTS=http://0.0.0.0:12379 /usr/local/bin/calicoctl node run

--- a/roles/prep-bootstrap-cni/tasks/deploy-cni.yaml
+++ b/roles/prep-bootstrap-cni/tasks/deploy-cni.yaml
@@ -1,0 +1,16 @@
+---
+- name: Ensures CNI binary directory exists
+  file:
+    path: /opt/cni/bin
+    state: directory
+
+- name: Ensures CNI config directory exists
+  file:
+    path: /etc/cni/net.d
+    state: directory
+
+- name: Install CNI binaries
+  unarchive:
+    src: "https://github.com/containernetworking/cni/releases/download/{{ cni_version }}/cni-amd64-{{ cni_version }}.tgz"
+    dest: /opt/cni/bin
+    remote_src: True

--- a/roles/prep-bootstrap-cni/tasks/deploy-sdn.yaml
+++ b/roles/prep-bootstrap-cni/tasks/deploy-sdn.yaml
@@ -1,0 +1,5 @@
+---
+- name: Ensures /etc/kubernetes/manifests dir exists
+  file:
+    path: /etc/kubernetes/manifests
+    state: directory

--- a/roles/prep-bootstrap-cni/tasks/main.yaml
+++ b/roles/prep-bootstrap-cni/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- include: deploy-cni.yaml
+- include: deploy-sdn.yaml
+- include: deploy-calico.yaml

--- a/roles/prep-bootstrap-cni/templates/calico-cni-config.j2
+++ b/roles/prep-bootstrap-cni/templates/calico-cni-config.j2
@@ -1,0 +1,16 @@
+{
+    "name": "calico-k8s-network",
+    "cniVersion": "{{ cni_version }}",
+    "type": "calico",
+    "etcd_endpoints": "http://{{ api_server_fqdn }}:12379",
+    "log_level": "info",
+    "ipam": {
+        "type": "calico-ipam"
+    },
+    "policy": {
+        "type": "k8s"
+    },
+    "kubernetes": {
+        "kubeconfig": "/etc/kubernetes/kubeconfig"
+    }
+}

--- a/roles/prep-bootstrap-cni/templates/calico-manifest.yaml.j2
+++ b/roles/prep-bootstrap-cni/templates/calico-manifest.yaml.j2
@@ -1,0 +1,144 @@
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "log_level": "debug",
+        "datastore_type": "kubernetes",
+        "hostname": "__KUBERNETES_NODE_NAME__",
+        "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:{{ calicoctl_version }}
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix debug logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "debug"
+            # Don't enable BGP.
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{ kube_cluster_cidr }}"
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # No IP address needed.
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:{{ calico_cni_plugin_version }}
+          command: ["/install-cni.sh"]
+          env:
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d

--- a/roles/prep-bootstrap-cni/templates/calico-policy-manifest.yaml.j2
+++ b/roles/prep-bootstrap-cni/templates/calico-policy-manifest.yaml.j2
@@ -1,0 +1,46 @@
+# Create this manifest using kubectl to deploy
+# the Calico policy controller on Kubernetes.
+# It deploys a single instance of the policy controller.
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+  labels:
+    k8s-app: calico-policy
+spec:
+  # Only a single instance of the policy controller should be
+  # active at a time.  Since this pod is run as a Deployment,
+  # Kubernetes will ensure the pod is recreated in case of failure,
+  # removing the need for passive backups.
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+      labels:
+        k8s-app: calico-policy
+    spec:
+      hostNetwork: true
+      containers:
+        - name: calico-policy-controller
+          # Make sure to pin this to your desired version.
+          image: quay.io/calico/kube-policy-controller:v0.5.4
+          env:
+            # Configure the policy controller with the location of
+            # your etcd cluster.
+            - name: ETCD_ENDPOINTS
+              value: "http://{{ api_server_fqdn }}:12379"
+            # Location of the Kubernetes API - this shouldn't need to be
+            # changed so long as it is used in conjunction with
+            # CONFIGURE_ETC_HOSTS="true".
+            - name: K8S_API
+              value: "https://{{ api_server_fqdn }}:443"
+            # Configure /etc/hosts within the container to resolve
+            # the kubernetes.default Service to the correct clusterIP
+            # using the environment provided by the kubelet.
+            # This removes the need for KubeDNS to resolve the Service.
+            - name: CONFIGURE_ETC_HOSTS
+              value: "true"

--- a/roles/prep-bootstrap-cni/templates/calico-v1.6-manifest.yaml.j2
+++ b/roles/prep-bootstrap-cni/templates/calico-v1.6-manifest.yaml.j2
@@ -1,0 +1,337 @@
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # The location of your etcd cluster.  This uses the Service clusterIP
+  # defined below.
+  etcd_endpoints: "http://{{ kube_cluster_ip }}:6666"
+
+  # Configure the Calico backend to use.
+  calico_backend: "bird"
+
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "etcd_endpoints": "__ETCD_ENDPOINTS__",
+        "log_level": "info",
+        "ipam": {
+            "type": "calico-ipam"
+        },
+        "policy": {
+            "type": "k8s",
+             "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+             "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
+        }
+    }
+
+---
+
+# This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
+# to force it to run on the master even when the master isn't schedulable, and uses
+# nodeSelector to ensure it only runs on the master.
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: calico-etcd
+  namespace: kube-system
+  labels:
+    k8s-app: calico-etcd
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-etcd
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # Only run this pod on the master.
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      hostNetwork: true
+      containers:
+        - name: calico-etcd
+          image: gcr.io/google_containers/etcd:2.2.1
+          env:
+            - name: CALICO_ETCD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          command: ["/bin/sh","-c"]
+          args: ["/usr/local/bin/etcd --name=calico --data-dir=/var/etcd/calico-data --advertise-client-urls=http://$CALICO_ETCD_IP:6666 --listen-client-urls=http://0.0.0.0:6666 --listen-peer-urls=http://0.0.0.0:6667"]
+          volumeMounts:
+            - name: var-etcd
+              mountPath: /var/etcd
+      volumes:
+        - name: var-etcd
+          hostPath:
+            path: /var/etcd
+
+---
+
+# This manfiest installs the Service which gets traffic to the Calico
+# etcd.
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: calico-etcd
+  name: calico-etcd
+  namespace: kube-system
+spec:
+  # Select the calico-etcd pod running on the master.
+  selector:
+    k8s-app: calico-etcd
+  # This ClusterIP needs to be known in advance, since we cannot rely
+  # on DNS to get access to etcd.
+  clusterIP: {{ kube_cluster_ip }}
+  ports:
+    - port: 6666
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: calico-cni-plugin
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:{{ calicoctl_version }}
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Enable BGP.  Disable to enforce policy only.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "{{ kube_cluster_cidr }}"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:{{ calico_cni_plugin_version }}
+          command: ["/install-cni.sh"]
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+
+---
+
+# This manifest deploys the Calico policy controller on Kubernetes.
+# See https://github.com/projectcalico/k8s-policy
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+  labels:
+    k8s-app: calico-policy
+spec:
+  # The policy controller can only have a single active instance.
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+      labels:
+        k8s-app: calico-policy-controller
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+    spec:
+      # The policy controller must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+      serviceAccountName: calico-policy-controller
+      containers:
+        - name: calico-policy-controller
+          image: quay.io/calico/kube-policy-controller:v0.5.4
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The location of the Kubernetes API.  Use the default Kubernetes
+            # service for API access.
+            - name: K8S_API
+              value: "https://kubernetes.default:443"
+            # Since we're running in the host namespace and might not have KubeDNS
+            # access, configure the container's /etc/hosts to resolve
+            # kubernetes.default to the correct service clusterIP.
+            - name: CONFIGURE_ETC_HOSTS
+              value: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-cni-plugin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-cni-plugin
+subjects:
+- kind: ServiceAccount
+  name: calico-cni-plugin
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+rules:
+  - apiGroups: [""]
+    resources:
+      - pods
+      - nodes
+    verbs:
+      - get
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-cni-plugin
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: calico-policy-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: calico-policy-controller
+subjects:
+- kind: ServiceAccount
+  name: calico-policy-controller
+  namespace: kube-system
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+rules:
+  - apiGroups:
+    - ""
+    - extensions
+    resources:
+      - pods
+      - namespaces
+      - networkpolicies
+    verbs:
+      - watch
+      - list
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system

--- a/roles/prep-bootstrap/tasks/main.yaml
+++ b/roles/prep-bootstrap/tasks/main.yaml
@@ -1,0 +1,4 @@
+---
+- include: prep-bootkube-host.yaml
+- include: prep-bootkube.yaml
+- include: prep-bootkube-render.yaml

--- a/roles/prep-bootstrap/tasks/prep-bootkube-host.yaml
+++ b/roles/prep-bootstrap/tasks/prep-bootkube-host.yaml
@@ -1,0 +1,23 @@
+---
+- name: Install base packages
+  when:
+    bootstrap_enabled
+  apt:
+    name: "{{ item }}"
+    state: present
+  with_items:
+    - "docker.io"
+    - "vim"
+    - "ethtool"
+    - "traceroute"
+    - "git"
+    - "build-essential"
+    - "lldpd"
+
+- name: Insert Temporary Hosts File Entry for FQDN Resolution
+  when:
+    bootstrap_enabled
+  lineinfile:
+    dest: /etc/hosts
+    line: "{{ hostvars[groups['master'][0]]['ansible_default_ipv4']['address'] }} {{ api_server_fqdn }}"
+    state: present

--- a/roles/prep-bootstrap/tasks/prep-bootkube-render.yaml
+++ b/roles/prep-bootstrap/tasks/prep-bootkube-render.yaml
@@ -1,0 +1,47 @@
+---
+- name: Clean previous bootkube assets if re-rendering and bootkube_render is flagged true
+  when:
+    - (bootstrap_enabled == 'true') and (bootkube_render == 'true')
+  file:
+    path: /tmp/bootkube/assets
+    state: absent
+
+- name: Clean up any previous bootkube deployments
+  file:
+    path: /tmp/bootkube/
+    state: absent
+
+- name: Ensure /tmp/bootkube directory is in a clean state
+  file:
+    path: /tmp/bootkube/
+    state: directory
+    owner: root
+    group: root
+
+- name: Render bootkube remotely
+  when:
+    - (bootstrap_enabled == 'true') and (bootkube_render == 'true')
+  command: "/usr/local/bin/bootkube render --asset-dir=/tmp/bootkube/assets --experimental-self-hosted-etcd --etcd-servers=http://10.3.0.15:2379 --api-servers=https://{{ api_server_fqdn }}:443"
+  args:
+    creates: /etc/kubernetes/kubeconfig
+
+- name: Copy remote bootkube rendered assets to local backup folder
+  when:
+    - (bootstrap_enabled == 'true') and (bootkube_render == 'true')
+  synchronize:
+    mode: pull
+    src: '/tmp/bootkube'
+    dest: '../files/backup'
+
+- name: Look for local deploy-host bootkube rendered assets folder
+  become: false
+  when:
+    - (bootstrap_enabled == 'true') and (bootkube_render == 'false')
+  local_action: stat path="../files/bootkube/assets"
+
+- name: Copy local bootkube rendered assets folder to bootkube host
+  when:
+    - (bootstrap_enabled == 'true') and (bootkube_render == 'false')
+  copy:
+    src: '../files/bootkube/'
+    dest: '/tmp/bootkube/'

--- a/roles/prep-bootstrap/tasks/prep-bootkube.yaml
+++ b/roles/prep-bootstrap/tasks/prep-bootkube.yaml
@@ -1,0 +1,37 @@
+---
+- name: Ensures bootkube dir exists
+  when:
+    bootstrap_enabled
+  file:
+    path: /tmp/bootkube
+    state: directory
+
+- name: Extract bootkube binaries
+  when:
+    bootstrap_enabled
+  unarchive:
+    src: "https://github.com/kubernetes-incubator/bootkube/releases/download/{{ boot_kube_version }}/bootkube.tar.gz"
+    dest: /tmp/bootkube
+    remote_src: True
+
+- name: Move bootkube binary to /usr/local/bin/
+  when:
+    bootstrap_enabled
+  copy:
+    remote_src: true
+    src: /tmp/bootkube/bin/linux/bootkube
+    dest: /usr/local/bin/bootkube
+    owner: root
+    group: root
+    mode: 0655
+
+- name: Move checkpoint binary to /usr/local/bin/
+  when:
+    bootstrap_enabled
+  copy:
+    remote_src: true
+    src: /tmp/bootkube/bin/linux/checkpoint
+    dest: /usr/local/bin/checkpoint
+    owner: root
+    group: root
+    mode: 0655

--- a/roles/prep-bootstrap/templates/bootkube.service
+++ b/roles/prep-bootstrap/templates/bootkube.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Kubernetes Control Plane Bootstrapping
+Documentation=https://github.com/kubernetes-incubator/bootkube
+
+[Service]
+ExecStart=/tmp/bootkube/bin/linux/bootkube start --asset-dir=/tmp/bootkube/assets/  --experimental-self-hosted-etcd --etcd-server=http://127.0.0.1:12379
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/prep-bootstrap/templates/calico.yaml
+++ b/roles/prep-bootstrap/templates/calico.yaml
@@ -1,0 +1,267 @@
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # The location of your etcd cluster.  This uses the Service clusterIP
+  # defined below.
+  etcd_endpoints: "http://10.96.232.136:6666"
+
+  # Configure the Calico backend to use.
+  calico_backend: "bird"
+
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "etcd_endpoints": "__ETCD_ENDPOINTS__",
+        "log_level": "info",
+        "ipam": {
+            "type": "calico-ipam"
+        },
+        "policy": {
+            "type": "k8s",
+             "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+             "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
+        }
+    }
+
+---
+
+# This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
+# to force it to run on the master even when the master isn't schedulable, and uses
+# nodeSelector to ensure it only runs on the master.
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: calico-etcd
+  namespace: kube-system
+  labels:
+    k8s-app: calico-etcd
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-etcd
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      # Only run this pod on the master.
+      nodeSelector:
+        kubeadm.alpha.kubernetes.io/role: master
+      hostNetwork: true
+      containers:
+        - name: calico-etcd
+          image: gcr.io/google_containers/etcd:2.2.1
+          env:
+            - name: CALICO_ETCD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          command: ["/bin/sh","-c"]
+          args: ["/usr/local/bin/etcd --name=calico --data-dir=/var/etcd/calico-data --advertise-client-urls=http://$CALICO_ETCD_IP:6666 --listen-client-urls=http://0.0.0.0:6666 --listen-peer-urls=http://0.0.0.0:6667"]
+          volumeMounts:
+            - name: var-etcd
+              mountPath: /var/etcd
+      volumes:
+        - name: var-etcd
+          hostPath:
+            path: /var/etcd
+
+---
+
+# This manfiest installs the Service which gets traffic to the Calico
+# etcd.
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: calico-etcd
+  name: calico-etcd
+  namespace: kube-system
+spec:
+  # Select the calico-etcd pod running on the master.
+  selector:
+    k8s-app: calico-etcd
+  # This ClusterIP needs to be known in advance, since we cannot rely
+  # on DNS to get access to etcd.
+  clusterIP: 10.96.232.136
+  ports:
+    - port: 6666
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v1.1.0
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Enable BGP.  Disable to enforce policy only.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "192.168.0.0/16"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:v1.6.1
+          command: ["/install-cni.sh"]
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+
+---
+
+# This manifest deploys the Calico policy controller on Kubernetes.
+# See https://github.com/projectcalico/k8s-policy
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+  labels:
+    k8s-app: calico-policy
+spec:
+  # The policy controller can only have a single active instance.
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+      labels:
+        k8s-app: calico-policy-controller
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      # The policy controller must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      containers:
+        - name: calico-policy-controller
+          image: quay.io/calico/kube-policy-controller:v0.5.4
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The location of the Kubernetes API.  Use the default Kubernetes
+            # service for API access.
+            - name: K8S_API
+              value: "https://kubernetes.default:443"
+            # Since we're running in the host namespace and might not have KubeDNS
+            # access, configure the container's /etc/hosts to resolve
+            # kubernetes.default to the correct service clusterIP.
+            - name: CONFIGURE_ETC_HOSTS
+              value: "true"

--- a/roles/prep-bootstrap/templates/kube-calico-cfg.yaml.j2
+++ b/roles/prep-bootstrap/templates/kube-calico-cfg.yaml.j2
@@ -1,0 +1,267 @@
+# This ConfigMap is used to configure a self-hosted Calico installation.
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # The location of your etcd cluster.  This uses the Service clusterIP
+  # defined below.
+  etcd_endpoints: "http://127.0.0.1:12379"
+
+  # Configure the Calico backend to use.
+  calico_backend: "bird"
+
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "etcd_endpoints": "__ETCD_ENDPOINTS__",
+        "log_level": "info",
+        "ipam": {
+            "type": "calico-ipam"
+        },
+        "policy": {
+            "type": "k8s",
+             "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+             "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "kubeconfig": "/etc/cni/net.d/__KUBECONFIG_FILENAME__"
+        }
+    }
+
+---
+
+# This manifest installs the Calico etcd on the kubeadm master.  This uses a DaemonSet
+# to force it to run on the master even when the master isn't schedulable, and uses
+# nodeSelector to ensure it only runs on the master.
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: calico-etcd
+  namespace: kube-system
+  labels:
+    k8s-app: calico-etcd
+spec:
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-etcd
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      # Only run this pod on the master.
+      nodeSelector:
+        kubeadm.alpha.kubernetes.io/role: master
+      hostNetwork: true
+      containers:
+        - name: calico-etcd
+          image: gcr.io/google_containers/etcd:2.2.1
+          env:
+            - name: CALICO_ETCD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+          command: ["/bin/sh","-c"]
+          args: ["/usr/local/bin/etcd --name=calico --data-dir=/var/etcd/calico-data --advertise-client-urls=http://$CALICO_ETCD_IP:12379 --listen-client-urls=http://0.0.0.0:12379 --listen-peer-urls=http://0.0.0.0:6667"]
+          volumeMounts:
+            - name: var-etcd
+              mountPath: /var/etcd
+      volumes:
+        - name: var-etcd
+          hostPath:
+            path: /var/etcd
+
+---
+
+# This manfiest installs the Service which gets traffic to the Calico
+# etcd.
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: calico-etcd
+  name: calico-etcd
+  namespace: kube-system
+spec:
+  # Select the calico-etcd pod running on the master.
+  selector:
+    k8s-app: calico-etcd
+  # This ClusterIP needs to be known in advance, since we cannot rely
+  # on DNS to get access to etcd.
+  clusterIP: 10.3.0.16
+  ports:
+    - port: 6666
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v1.1.0
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # Enable BGP.  Disable to enforce policy only.
+            - name: CALICO_NETWORKING_BACKEND
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: calico_backend
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Configure the IP Pool from which Pod IPs will be chosen.
+            - name: CALICO_IPV4POOL_CIDR
+              value: "192.168.0.0/16"
+            - name: CALICO_IPV4POOL_IPIP
+              value: "always"
+            # Disable IPv6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Set Felix logging to "info"
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "info"
+            # Auto-detect the BGP IP address.
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:v1.6.1
+          command: ["/install-cni.sh"]
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d
+
+---
+
+# This manifest deploys the Calico policy controller on Kubernetes.
+# See https://github.com/projectcalico/k8s-policy
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: calico-policy-controller
+  namespace: kube-system
+  labels:
+    k8s-app: calico-policy
+spec:
+  # The policy controller can only have a single active instance.
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      name: calico-policy-controller
+      namespace: kube-system
+      labels:
+        k8s-app: calico-policy-controller
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      # The policy controller must run in the host network namespace so that
+      # it isn't governed by policy that would prevent it from working.
+      hostNetwork: true
+      containers:
+        - name: calico-policy-controller
+          image: quay.io/calico/kube-policy-controller:v0.5.4
+          env:
+            # The location of the Calico etcd cluster.
+            - name: ETCD_ENDPOINTS
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: etcd_endpoints
+            # The location of the Kubernetes API.  Use the default Kubernetes
+            # service for API access.
+            - name: K8S_API
+              value: "https://kubernetes.default:443"
+            # Since we're running in the host namespace and might not have KubeDNS
+            # access, configure the container's /etc/hosts to resolve
+            # kubernetes.default to the correct service clusterIP.
+            - name: CONFIGURE_ETC_HOSTS
+              value: "true"

--- a/roles/prep-bootstrap/templates/kube-calico-cfg.yaml_WORKING.j2
+++ b/roles/prep-bootstrap/templates/kube-calico-cfg.yaml_WORKING.j2
@@ -1,0 +1,144 @@
+# This ConfigMap is used to configure a self-hosted Calico installation without ETCD
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: calico-config
+  namespace: kube-system
+data:
+  # The CNI network configuration to install on each node.
+  cni_network_config: |-
+    {
+        "name": "k8s-pod-network",
+        "type": "calico",
+        "log_level": "debug",
+        "datastore_type": "kubernetes",
+        "hostname": "__KUBERNETES_NODE_NAME__",
+        "ipam": {
+            "type": "host-local",
+            "subnet": "usePodCidr"
+        },
+        "policy": {
+            "type": "k8s",
+            "k8s_auth_token": "__SERVICEACCOUNT_TOKEN__"
+        },
+        "kubernetes": {
+            "k8s_api_root": "https://__KUBERNETES_SERVICE_HOST__:__KUBERNETES_SERVICE_PORT__",
+            "kubeconfig": "__KUBECONFIG_FILEPATH__"
+        }
+    }
+
+---
+
+# This manifest installs the calico/node container, as well
+# as the Calico CNI plugins and network config on
+# each master and worker node in a Kubernetes cluster.
+kind: DaemonSet
+apiVersion: extensions/v1beta1
+metadata:
+  name: calico-node
+  namespace: kube-system
+  labels:
+    k8s-app: calico-node
+spec:
+  selector:
+    matchLabels:
+      k8s-app: calico-node
+  template:
+    metadata:
+      labels:
+        k8s-app: calico-node
+      annotations:
+        scheduler.alpha.kubernetes.io/critical-pod: ''
+        scheduler.alpha.kubernetes.io/tolerations: |
+          [{"key": "dedicated", "value": "master", "effect": "NoSchedule" },
+           {"key":"CriticalAddonsOnly", "operator":"Exists"}]
+    spec:
+      hostNetwork: true
+      containers:
+        # Runs calico/node container on each Kubernetes node.  This
+        # container programs network policy and routes on each
+        # host.
+        - name: calico-node
+          image: quay.io/calico/node:v1.1.0
+          env:
+            # Use Kubernetes API as the backing datastore.
+            - name: DATASTORE_TYPE
+              value: "kubernetes"
+            # Enable felix debug logging.
+            - name: FELIX_LOGSEVERITYSCREEN
+              value: "debug"
+            # Don't enable BGP.
+            - name: CALICO_NETWORKING_BACKEND
+              value: "none"
+            # Disable file logging so `kubectl logs` works.
+            - name: CALICO_DISABLE_FILE_LOGGING
+              value: "true"
+            # Set Felix endpoint to host default action to ACCEPT.
+            - name: FELIX_DEFAULTENDPOINTTOHOSTACTION
+              value: "ACCEPT"
+            # Disable IPV6 on Kubernetes.
+            - name: FELIX_IPV6SUPPORT
+              value: "false"
+            # Wait for the datastore.
+            - name: WAIT_FOR_DATASTORE
+              value: "true"
+            # The Calico IPv4 pool to use.  This should match `--cluster-cidr`
+            - name: CALICO_IPV4POOL_CIDR
+              value: "10.244.0.0/16"
+            # Set based on the k8s node name.
+            - name: NODENAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            # No IP address needed.
+            - name: IP
+              value: ""
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              cpu: 250m
+          volumeMounts:
+            - mountPath: /lib/modules
+              name: lib-modules
+              readOnly: true
+            - mountPath: /var/run/calico
+              name: var-run-calico
+              readOnly: false
+        # This container installs the Calico CNI binaries
+        # and CNI network config file on each node.
+        - name: install-cni
+          image: quay.io/calico/cni:v1.6.1
+          command: ["/install-cni.sh"]
+          env:
+            # The CNI network config to install on each node.
+            - name: CNI_NETWORK_CONFIG
+              valueFrom:
+                configMapKeyRef:
+                  name: calico-config
+                  key: cni_network_config
+            # Set the hostname based on the k8s node name.
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /host/opt/cni/bin
+              name: cni-bin-dir
+            - mountPath: /host/etc/cni/net.d
+              name: cni-net-dir
+      volumes:
+        # Used by calico/node.
+        - name: lib-modules
+          hostPath:
+            path: /lib/modules
+        - name: var-run-calico
+          hostPath:
+            path: /var/run/calico
+        # Used to install CNI.
+        - name: cni-bin-dir
+          hostPath:
+            path: /opt/cni/bin
+        - name: cni-net-dir
+          hostPath:
+            path: /etc/cni/net.d

--- a/roles/prep-bootstrap/templates/kube-calico.yaml.j2
+++ b/roles/prep-bootstrap/templates/kube-calico.yaml.j2
@@ -1,0 +1,1 @@
+#Nothing To Be Seen Here.  Prevents Bootkube from coming up

--- a/roles/prep-bootstrap/templates/kube-controller-manager.json
+++ b/roles/prep-bootstrap/templates/kube-controller-manager.json
@@ -1,0 +1,75 @@
+{
+  "kind": "Pod",
+  "apiVersion": "v1",
+  "metadata": {
+    "name": "kube-controller-manager",
+    "namespace": "kube-system",
+    "creationTimestamp": null,
+    "labels": {
+      "component": "kube-controller-manager",
+      "tier": "control-plane"
+    }
+  },
+  "spec": {
+    "volumes": [
+      {
+        "name": "k8s",
+        "hostPath": {
+          "path": "/etc/kubernetes"
+        }
+      },
+      {
+        "name": "certs",
+        "hostPath": {
+          "path": "/etc/ssl/certs"
+        }
+      }
+    ],
+    "containers": [
+      {
+        "name": "kube-controller-manager",
+        "image": "quay.io/attcomdev/kube-controller-manager:{{ kube_controller_manager_version }}",
+        "command": [
+          "kube-controller-manager",
+          "--address=127.0.0.1",
+          "--leader-elect",
+          "--master=127.0.0.1:8080",
+          "--cluster-name=kubernetes",
+          "--root-ca-file=/etc/kubernetes/pki/ca.pem",
+          "--service-account-private-key-file=/etc/kubernetes/pki/apiserver-key.pem",
+          "--cluster-signing-cert-file=/etc/kubernetes/pki/ca.pem",
+          "--cluster-signing-key-file=/etc/kubernetes/pki/ca-key.pem",
+          "--insecure-experimental-approve-all-kubelet-csrs-for-group=system:kubelet-bootstrap"
+        ],
+        "resources": {
+          "requests": {
+            "cpu": "200m"
+          }
+        },
+        "volumeMounts": [
+          {
+            "name": "k8s",
+            "readOnly": true,
+            "mountPath": "/etc/kubernetes/"
+          },
+          {
+            "name": "certs",
+            "mountPath": "/etc/ssl/certs"
+          }
+        ],
+        "livenessProbe": {
+          "httpGet": {
+            "path": "/healthz",
+            "port": 10252,
+            "host": "127.0.0.1"
+          },
+          "initialDelaySeconds": 15,
+          "timeoutSeconds": 15,
+          "failureThreshold": 8
+        }
+      }
+    ],
+    "hostNetwork": true
+  },
+  "status": {}
+}

--- a/roles/prep-bootstrap/templates/kube-controller-manager.yaml
+++ b/roles/prep-bootstrap/templates/kube-controller-manager.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-controller-manager
+  namespace: kube-system
+  labels:
+    k8s-app: kube-controller-manager
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        k8s-app: kube-controller-manager
+    spec:
+      nodeSelector:
+        master: "true"
+      containers:
+      - name: kube-controller-manager
+        image: quay.io/attcomdev/kube-controller-manager:{{ kube_controller_manager_version }}
+        command:
+        - ./hyperkube
+        - controller-manager
+        - --allocate-node-cidrs=true
+        - --configure-cloud-routes=false
+        - --cluster-cidr=10.2.0.0/16
+        - --root-ca-file=/etc/kubernetes/secrets/ca.crt
+        - --service-account-private-key-file=/etc/kubernetes/secrets/service-account.key
+        - --leader-elect=true
+        - --cloud-provider=
+        volumeMounts:
+        - name: secrets
+          mountPath: /etc/kubernetes/secrets
+          readOnly: true
+        - name: ssl-host
+          mountPath: /etc/ssl/certs
+          readOnly: true
+      volumes:
+      - name: secrets
+        secret:
+          secretName: kube-controller-manager
+      - name: ssl-host
+        hostPath:
+          path: /usr/share/ca-certificates
+      dnsPolicy: Default # Don't use cluster DNS.

--- a/site.yaml
+++ b/site.yaml
@@ -1,23 +1,47 @@
+- hosts: all
+  remote_user: ubuntu
+  become: yes
+  become_method: sudo
+  roles:
+    - prep-bootstrap-cleanup
+
 - hosts: bootstrap
   remote_user: ubuntu
   become: yes
   become_method: sudo
   roles:
-    - deploy-bootstrap
+    - prep-bootstrap
+
+- hosts: all
+  remote_user: ubuntu
+  become: yes
+  become_method: sudo
+  roles:
+    - prep-bootstrap-cni
+
+- hosts: all
+  remote_user: ubuntu
+  become: yes
+  become_method: sudo
+  roles:
+    - deploy-kubelet
 
 - hosts: master
   remote_user: ubuntu
   become: yes
   become_method: sudo
   roles:
-    - deploy-kubelet
+    - deploy-bootkube
 
-- hosts: workers
-  remote_user: ubuntu
-  become: yes
-  become_method: sudo
-  roles:
-    - deploy-kubelet
+
+#- hosts: master
+#  remote_user: ubuntu
+#  become: yes
+#  become_method: sudo
+#  roles:
+#    - deploy-kubelet
+
+
 
 #- hosts: master
 #  remote_user: ubuntu


### PR DESCRIPTION
This deployment has a few WIP items:

* Allows for BYO assets rendered from another bootkube environment (for future automated containerized bootkube rendering).
* Adds backup feature for `promenade` generated bootkube renders.
* Also allows for  optional (with variable override) generated bootstrap-host bootkube rendering
* Adds a `promenade` "command" for the deployment
* Overhauls the workflow in role separation
* Resolved DNS issues, which were causing long delays when issuing `kubectl` commands
* Starts the Kubelet process first, for easier deployment debugging
* Add Calico CNI plugin binaries (missing previously)
* Introduces  the concept of post-deployment add-ons (still debating if this even needs to exist; may be removed entirely soon).
* Introduce the concept of site-specific deployment inventories (WIP: to be continued).
* Introduce the concept of removing vars from inventory file
* Introduce optional cleanup in situations where an operator may wish to redeploy/test several times.
* Introduces several variable improvements