### PR TITLE
Enable or Disable image prefetching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 /helm
 /kubelet
 /linux-amd64
+/genesis_image_cache/
+/join_image_cache/

--- a/Dockerfile.genesis
+++ b/Dockerfile.genesis
@@ -29,7 +29,7 @@ WORKDIR /promenade
 
 ENTRYPOINT /promenade/scripts/entrypoint.sh
 
-COPY genesis-images.tar cni.tgz helm kubelet /promenade/
+COPY genesis_image_cache/* cni.tgz helm kubelet /promenade/
 
 COPY kubelet.service.template /promenade/
 COPY env.sh scripts/common/* /promenade/scripts/

--- a/Dockerfile.join
+++ b/Dockerfile.join
@@ -29,7 +29,7 @@ WORKDIR /promenade
 
 ENTRYPOINT /promenade/scripts/entrypoint.sh
 
-COPY join-images.tar cni.tgz kubelet /promenade/
+COPY join_image_cache/* cni.tgz kubelet /promenade/
 
 COPY kubelet.service.template /promenade/
 COPY env.sh scripts/common/* /promenade/scripts/

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ JOIN_IMAGES := \
 	quay.io/coreos/kenc:48b6feceeee56c657ea9263f47b6ea091e8d3035 \
 	quay.io/coreos/pod-checkpointer:20cf8b9a6018731a0770192f30dfa7a1941521e3 \
 
-#Build Deps
+#Build Dependencies online vs offline
 GENESIS_BUILD_DEPS := Dockerfile.genesis cni.tgz env.sh helm kubelet kubelet.service.template
 
 ifeq ($(PREFETCH_IMAGES), true)

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,9 @@ GENESIS_REPO := promenade-genesis
 JOIN_REPO := promenade-join
 TAG := dev
 
+#PreFetch Images for Offline deployment
+PREFETCH_IMAGES := true
+
 GENESIS_IMAGES := \
 	gcr.io/google_containers/k8s-dns-dnsmasq-nanny-amd64:1.14.1 \
 	gcr.io/google_containers/k8s-dns-kube-dns-amd64:1.14.1 \
@@ -72,8 +75,14 @@ save: save-genesis save-join
 
 genesis: build-genesis
 
+ifeq ($(PREFETCH_IMAGES), true)
 build-genesis: Dockerfile.genesis cni.tgz env.sh helm genesis-images.tar kubelet kubelet.service.template
 	sudo docker build -f Dockerfile.genesis -t $(NAMESPACE)/$(GENESIS_REPO):$(TAG) .
+else
+build-genesis: Dockerfile.genesis cni.tgz env.sh helm kubelet kubelet.service.template
+	sudo docker build -f Dockerfile.genesis -t $(NAMESPACE)/$(GENESIS_REPO):$(TAG) .
+endif
+
 
 push-genesis: build-genesis
 	sudo docker push $(NAMESPACE)/$(GENESIS_REPO):$(TAG)
@@ -84,9 +93,13 @@ save-genesis: build-genesis
 
 join: build-join
 
+ifeq ($(PREFETCH_IMAGES), true)
 build-join: Dockerfile.join join-images.tar kubelet.service.template
 	sudo docker build -f Dockerfile.join -t $(NAMESPACE)/$(JOIN_REPO):$(TAG) .
-
+else
+build-join: Dockerfile.join kubelet.service.template
+	sudo docker build -f Dockerfile.join -t $(NAMESPACE)/$(JOIN_REPO):$(TAG) .
+endif
 push-join: build-join
 	sudo docker push $(NAMESPACE)/$(JOIN_REPO):$(TAG)
 
@@ -115,13 +128,15 @@ genesis-images.tar:
 	for IMAGE in $(GENESIS_IMAGES); do \
 		sudo docker pull $$IMAGE; \
 	done
-	sudo docker save -o genesis-images.tar $(GENESIS_IMAGES)
+	mkdir genesis_image_cache
+	sudo docker save -o genesis_image_cache/genesis-images.tar $(GENESIS_IMAGES)
 
 join-images.tar:
 	for IMAGE in $(JOIN_IMAGES); do \
 		sudo docker pull $$IMAGE; \
 	done
-	sudo docker save -o join-images.tar $(JOIN_IMAGES)
+	mkdir join_image_cache
+	sudo docker save -o join_image_cache/join-images.tar $(JOIN_IMAGES)
 
 kubelet:
 	curl -LO http://storage.googleapis.com/kubernetes-release/release/$(KUBERNETES_VERSION)/bin/linux/amd64/kubelet
@@ -136,6 +151,8 @@ clean:
 		helm.tgz \
 		kubelet \
 		linux-amd64 \
+		genesis_image_cache \
+		join_image_cache \
 
 
 .PHONY : build build-genesis build-join clean genesis join push push-genesis push-join

--- a/scripts/entrypoint-genesis.sh
+++ b/scripts/entrypoint-genesis.sh
@@ -22,7 +22,11 @@ source ./scripts/func.sh
 validate_environment
 # XXX validate_genesis_assets
 
-docker load -i ./genesis-images.tar
+if [ -f "genesis_image_cache/genesis-images.tar" ]; then
+  docker load -i ./genesis-images.tar
+else
+  echo "Image Cache Not Found.. Skipping."
+fi
 
 install_assets
 install_cni


### PR DESCRIPTION
Adding the ability to enable or disable prefetching the docker images in the Makefile. This is will assist with online vs offline deployments. The default is set to `true`, but can be disabled allowing Bootkube to pull images from Quay or Docker Hub. 