### PR TITLE
Make kube-dns upstream servers configurable

### DIFF
--- a/example/vagrant-input-config.yaml
+++ b/example/vagrant-input-config.yaml
@@ -44,3 +44,6 @@ spec:
   kube_service_ip: 10.96.0.1
   pod_ip_cidr: 10.97.0.0/16
   service_ip_cidr: 10.96.0.0/16
+  dns_servers:
+    - 8.8.8.8
+    - 8.8.4.4

--- a/promenade/templates/genesis/etc/kubernetes/asset-loader/assets/kube-dns.yaml
+++ b/promenade/templates/genesis/etc/kubernetes/asset-loader/assets/kube-dns.yaml
@@ -7,8 +7,7 @@ metadata:
   labels:
     addonmanager.kubernetes.io/mode: EnsureExists
 data:
-  upstreamNameservers: |-
-    ["8.8.8.8", "8.8.4.4"]
+  upstreamNameservers: {{ config['Network']['dns_servers'] | tojson }}
 
 ---
 apiVersion: v1


### PR DESCRIPTION
This uses dns servers specified in the `Network` config document to control kube-dns upstream servers.