### PR TITLE
Add initial Armada loader

### DIFF
--- a/promenade/generator.py
+++ b/promenade/generator.py
@@ -77,7 +77,7 @@ class Generator:
         ]).write(os.path.join(output_dir, 'admin-bundle.yaml'))
 
         for hostname, data in cluster['nodes'].items():
-            if 'genesis' in data['roles']:
+            if 'genesis' in data.get('roles', []):
                 genesis_hostname = hostname
                 break
 
@@ -119,7 +119,7 @@ class Generator:
             ]
             role_specific_documents = []
 
-            if 'master' in data['roles']:
+            if 'master' in data.get('roles', []):
                 role_specific_documents.extend([
                     admin_cert,
                     admin_cert_key,
@@ -129,7 +129,7 @@ class Generator:
                     sa_priv,
                     sa_pub,
                 ])
-                if 'genesis' not in data['roles']:
+                if 'genesis' not in data.get('roles', []):
                     role_specific_documents.append(
                         _master_etcd_config(cluster_name, genesis_hostname,
                                             hostname, masters)
@@ -137,7 +137,7 @@ class Generator:
                 role_specific_documents.extend(_master_config(hostname, data,
                                                               masters, network, keys))
 
-            if 'genesis' in data['roles']:
+            if 'genesis' in data.get('roles', []):
                 role_specific_documents.extend(_genesis_config(hostname, data,
                                                                masters, network, keys))
                 role_specific_documents.append(_genesis_etcd_config(cluster_name, hostname))
@@ -149,7 +149,7 @@ class Generator:
     def construct_masters(self, cluster_name):
         masters = []
         for hostname, data in self.input_config['Cluster']['nodes'].items():
-            if 'master' in data['roles'] or 'genesis' in data['roles']:
+            if 'master' in data.get('roles', []) or 'genesis' in data.get('roles', []):
                 masters.append({'hostname': hostname, 'ip': data['ip']})
 
         return config.Document({
@@ -303,8 +303,8 @@ def _construct_node_config(cluster_name, hostname, data):
     spec = {
         'hostname': hostname,
         'ip': data['ip'],
-        'labels': _labels(data['roles'], data.get('additional_labels', [])),
-        'templates': _templates(data['roles']),
+        'labels': _labels(data.get('roles', []), data.get('additional_labels', [])),
+        'templates': _templates(data.get('roles', [])),
     }
 
     return config.Document({

--- a/promenade/templates/genesis/etc/kubernetes/armada-loader/kubeconfig.yaml
+++ b/promenade/templates/genesis/etc/kubernetes/armada-loader/kubeconfig.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: v1
+clusters:
+- cluster:
+    server: https://kubernetes.default.svc.{{ config['Network']['cluster_domain'] }}
+    certificate-authority: /etc/kubernetes/armada-loader/pki/cluster-ca.pem
+  name: kubernetes
+contexts:
+- context:
+    cluster: kubernetes
+    user: armada-loader
+  name: armada-loader@kubernetes
+current-context: armada-loader@kubernetes
+kind: Config
+preferences: {}
+users:
+- name: armada-loader
+  user:
+    client-certificate: /etc/kubernetes/armada-loader/pki/armada-loader.pem
+    client-key: /etc/kubernetes/armada-loader/pki/armada-loader-key.pem

--- a/promenade/templates/genesis/etc/kubernetes/armada-loader/pki/armada-loader-key.pem
+++ b/promenade/templates/genesis/etc/kubernetes/armada-loader/pki/armada-loader-key.pem
@@ -1,0 +1,1 @@
+{{ config.get(kind='CertificateKey', name='admin')['data'] }}

--- a/promenade/templates/genesis/etc/kubernetes/armada-loader/pki/armada-loader.pem
+++ b/promenade/templates/genesis/etc/kubernetes/armada-loader/pki/armada-loader.pem
@@ -1,0 +1,1 @@
+{{ config.get(kind='Certificate', name='admin')['data'] }}

--- a/promenade/templates/genesis/etc/kubernetes/armada-loader/pki/cluster-ca.pem
+++ b/promenade/templates/genesis/etc/kubernetes/armada-loader/pki/cluster-ca.pem
@@ -1,0 +1,1 @@
+{{ config.get(kind='CertificateAuthority', name='cluster')['data'] }}

--- a/promenade/templates/genesis/etc/kubernetes/kubelet/manifests/armada-loader.yaml
+++ b/promenade/templates/genesis/etc/kubernetes/kubelet/manifests/armada-loader.yaml
@@ -1,0 +1,48 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: armada-loader
+  namespace: kube-system
+  labels:
+    app: promenade
+    component: armada-loader
+spec:
+  containers:
+    - name: loader
+      image: quay.io/attcomdev/armada:master
+      command:
+        - /bin/bash
+        - -c
+        - |-
+            set -x
+
+            cd /etc/kubernetes/armada-loader/assets
+            if [ -s promenade-armada.yaml ]; then
+              mkdir -p /root/.kube
+              cp /etc/kubernetes/armada-loader/kubeconfig.yaml /root/.kube/config
+
+              while true; do
+                sleep 60
+                if armada apply promenade-armada.yaml ; then
+                  break
+                fi
+              done
+            fi
+
+            rm -rf /etc/kubernetes/kubelet/manifests/armada-loader.yaml
+            sleep 10000
+
+      volumeMounts:
+        - name: config
+          mountPath: /etc/kubernetes/armada-loader
+          readOnly: true
+        - name: manifests
+          mountPath: /etc/kubernetes/kubelet/manifests
+  volumes:
+    - name: config
+      hostPath:
+        path: /etc/kubernetes/armada-loader
+    - name: manifests
+      hostPath:
+        path: /etc/kubernetes/kubelet/manifests

--- a/promenade/templates/genesis/etc/kubernetes/kubelet/manifests/armada-loader.yaml
+++ b/promenade/templates/genesis/etc/kubernetes/kubelet/manifests/armada-loader.yaml
@@ -31,6 +31,7 @@ spec:
             fi
 
             rm -rf /etc/kubernetes/kubelet/manifests/armada-loader.yaml
+            # Sleep so that kubelet doesn't restart this pod before it kills it
             sleep 10000
 
       volumeMounts:


### PR DESCRIPTION
This adds a basic armada loader.  To use it, you must put resources on the genesis host at `/etc/kubernetes/armada-loader/assets`, including the actual armada file named `promenade-armada.yaml`.

This uses the admin cert for now.