### PR TITLE
Add configuration bundle for Drydock export

### DIFF
--- a/promenade/config.py
+++ b/promenade/config.py
@@ -54,6 +54,10 @@ class Document:
         return self.metadata['name']
 
     @property
+    def alias(self):
+        return self.metadata.get('alias')
+
+    @property
     def target(self):
         return self.metadata.get('target')
 
@@ -91,9 +95,11 @@ class Configuration:
         else:
             return results[0]
 
-    def get(self, *, kind, name):
+    def get(self, *, kind, alias=None, name=None):
         for document in self.documents:
-            if document.kind == kind and document.name == name:
+            if (document.kind == kind
+                    and (not alias or document.alias == alias)
+                    and (not name or document.name == name)) :
                 return document
 
     def iterate(self, *, kind=None, target=None):

--- a/promenade/pki.py
+++ b/promenade/pki.py
@@ -61,14 +61,17 @@ class PKI:
             alias = name
 
         return (self._wrap('PublicKey', pub_result['pub.pem'],
-                           name=alias,
+                           alias=alias,
+                           name=name,
                            target=target),
                 self._wrap('PrivateKey', priv_result['priv.pem'],
-                           name=alias,
+                           alias=alias,
+                           name=name,
                            target=target))
 
 
-    def generate_certificate(self, *, alias=None, ca_name, groups=[], hosts=[], name, target):
+    def generate_certificate(self, *, alias=None, config_name=None,
+                             ca_name, groups=[], hosts=[], name, target):
         result = self._cfssl(
                 ['gencert',
                  '-ca', 'ca.pem',
@@ -85,11 +88,16 @@ class PKI:
         if not alias:
             alias = name
 
+        if not config_name:
+            config_name = name
+
         return (self._wrap('Certificate', result['cert'],
-                           name=alias,
+                           alias=alias,
+                           name=config_name,
                            target=target),
                 self._wrap('CertificateKey', result['key'],
-                           name=alias,
+                           alias=alias,
+                           name=config_name,
                            target=target))
 
     def csr(self, *, name, groups=[], hosts=[], key={'algo': 'rsa', 'size': 2048}):

--- a/promenade/templates/common/etc/kubernetes/kubelet/pki/kubelet-key.pem
+++ b/promenade/templates/common/etc/kubernetes/kubelet/pki/kubelet-key.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='CertificateKey', name='kubelet')['data'] }}
+{{ config.get(kind='CertificateKey', alias='kubelet')['data'] }}

--- a/promenade/templates/common/etc/kubernetes/kubelet/pki/kubelet.pem
+++ b/promenade/templates/common/etc/kubernetes/kubelet/pki/kubelet.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='Certificate', name='kubelet')['data'] }}
+{{ config.get(kind='Certificate', alias='kubelet')['data'] }}

--- a/promenade/templates/common/etc/kubernetes/proxy/pki/proxy-key.pem
+++ b/promenade/templates/common/etc/kubernetes/proxy/pki/proxy-key.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='CertificateKey', name='proxy')['data'] }}
+{{ config.get(kind='CertificateKey', alias='proxy')['data'] }}

--- a/promenade/templates/common/etc/kubernetes/proxy/pki/proxy.pem
+++ b/promenade/templates/common/etc/kubernetes/proxy/pki/proxy.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='Certificate', name='proxy')['data'] }}
+{{ config.get(kind='Certificate', alias='proxy')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/apiserver/pki/apiserver-key.pem
+++ b/promenade/templates/master/etc/kubernetes/apiserver/pki/apiserver-key.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='CertificateKey', name='apiserver')['data'] }}
+{{ config.get(kind='CertificateKey', alias='apiserver')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/apiserver/pki/apiserver.pem
+++ b/promenade/templates/master/etc/kubernetes/apiserver/pki/apiserver.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='Certificate', name='apiserver')['data'] }}
+{{ config.get(kind='Certificate', alias='apiserver')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/apiserver/pki/etcd-client-key.pem
+++ b/promenade/templates/master/etc/kubernetes/apiserver/pki/etcd-client-key.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='CertificateKey', name='etcd-apiserver-client')['data'] }}
+{{ config.get(kind='CertificateKey', alias='etcd-apiserver-client')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/apiserver/pki/etcd-client.pem
+++ b/promenade/templates/master/etc/kubernetes/apiserver/pki/etcd-client.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='Certificate', name='etcd-apiserver-client')['data'] }}
+{{ config.get(kind='Certificate', alias='etcd-apiserver-client')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/controller-manager/pki/controller-manager-key.pem
+++ b/promenade/templates/master/etc/kubernetes/controller-manager/pki/controller-manager-key.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='CertificateKey', name='controller-manager')['data'] }}
+{{ config.get(kind='CertificateKey', alias='controller-manager')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/controller-manager/pki/controller-manager.pem
+++ b/promenade/templates/master/etc/kubernetes/controller-manager/pki/controller-manager.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='Certificate', name='controller-manager')['data'] }}
+{{ config.get(kind='Certificate', alias='controller-manager')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/etcd/pki/etcd-client-key.pem
+++ b/promenade/templates/master/etc/kubernetes/etcd/pki/etcd-client-key.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='CertificateKey', name='etcd-client')['data'] }}
+{{ config.get(kind='CertificateKey', alias='etcd-client')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/etcd/pki/etcd-client.pem
+++ b/promenade/templates/master/etc/kubernetes/etcd/pki/etcd-client.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='Certificate', name='etcd-client')['data'] }}
+{{ config.get(kind='Certificate', alias='etcd-client')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/etcd/pki/etcd-peer-key.pem
+++ b/promenade/templates/master/etc/kubernetes/etcd/pki/etcd-peer-key.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='CertificateKey', name='etcd-peer')['data'] }}
+{{ config.get(kind='CertificateKey', alias='etcd-peer')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/etcd/pki/etcd-peer.pem
+++ b/promenade/templates/master/etc/kubernetes/etcd/pki/etcd-peer.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='Certificate', name='etcd-peer')['data'] }}
+{{ config.get(kind='Certificate', alias='etcd-peer')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/scheduler/pki/scheduler-key.pem
+++ b/promenade/templates/master/etc/kubernetes/scheduler/pki/scheduler-key.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='CertificateKey', name='scheduler')['data'] }}
+{{ config.get(kind='CertificateKey', alias='scheduler')['data'] }}

--- a/promenade/templates/master/etc/kubernetes/scheduler/pki/scheduler.pem
+++ b/promenade/templates/master/etc/kubernetes/scheduler/pki/scheduler.pem
@@ -1,1 +1,1 @@
-{{ config.get(kind='Certificate', name='scheduler')['data'] }}
+{{ config.get(kind='Certificate', alias='scheduler')['data'] }}


### PR DESCRIPTION
This adds an additional output file to the generate sub-command, which dumps a (nearly) complete collection of configuration documents into a single file without duplicates.  This should be suitable for upload into Drydock.

This is a bigger change than I expected, because I had been a bit sloppy in my mixing of `name` and `alias` in the first pass at this development.

I think we should revisit this in the future and structure the metadata more strictly perhaps even using only label selectors.  Then the config queries from templates can do label selection instead of having two kinds of "names".

For now though, the gist is that `alias` is meant to be like a label selector that can be reused on multiple hosts for different data on each host.  This way the templates don't have to do anything complex in their queries -- they just say things like `alias='kubelet'`.

Additionally, I had validation in place to check that there were no duplicate values of `name` per `kind`.  I think this is good, and I didn't want to remove that.  However, I had again coupled the `name` field with other data.  In this case it was the `CN` of the certs.  For most cases, this wasn't a problem, because they embedded the hostname, but for the kube proxy, it actually needs to use the same `CN` for all hosts.  Maybe the kubernetes authors are expecting it to always be a `DaemonSet`.

Anyway, I added a specific override for the name in the `config.Document` when generating a cert, called `config_name` just to handle the proxy case.