### PR TITLE
WIP:  Enable SHA256 Hashing of Promenade Generated Files

### DIFF
--- a/promenade/host_validation.py
+++ b/promenade/host_validation.py
@@ -1,0 +1,22 @@
+from . import *
+import os subprocess
+import requests
+import logger
+
+
+#Validate Kubelet is running without error
+def check_k8s():
+    pass
+#Validate the Promenade files match the SHA Hashes
+def validate_sha():
+    pass
+
+#Validate Kubernetes API Response
+def validate_api():
+    api_request_external = requests.get('http://localhost:8080')
+    if api_request.status_code == 200:
+        log.info("K8's External API API is responding")
+    else:
+        log.debug("K8's API is not responding")
+    #TODO: Figure out a way to get the internal API Request IP
+    #api_request_internal = request.get('http://')

--- a/promenade/renderer.py
+++ b/promenade/renderer.py
@@ -51,25 +51,24 @@ class Renderer:
 
         LOG.info('Installed "%s"', os.path.join('/', base_path))
 
+#Generate SHA256 Hases of all the files for host validation
     def generate_sha_hashes(self, *, path, root):
         base_path = os.path.relpath(path, root)
         target_path = os.path.join(self.target_dir, base_path)
         log_path = "var/log/promenade/"
-        LOG.info('VARIABLE REVEAL: self.target_dir is:"%s" and base_path is: "%s" and target_path is "%s"', self.target_dir, base_path, target_path)
         target_log_path = os.path.join(self.target_dir, log_path)
-        log_file = os.path.join(target_log_path, "modified_file_check.txt")
-        try:
-            LOG.debug('Creating "%s"', target_log_path)
+        log_file = os.path.join(target_log_path, "promenade_file_hash.log")
+        if not os.path.exists(target_log_path):
+            LOG.info('Creating "%s"', target_log_path)
             os.mkdir(target_log_path)
-        except OSError:
-            LOG.debug('Skipping creation of "%s" because it already exists', target_log_path)
-
+        else:
+            LOG.info('Skipping creation of "%s" because it already exists', target_log_path)
+#Generate Hashes and Write to file
         hash_sums = {}
         hash = hashlib.sha256(open(path,'rb').read()).hexdigest()
-        hash_sums[target_path] = hash
-        #os.chdir(log_path)
-        LOG.info('HASHING:  "%s" into "%s"', hash_sums, target_path)
-        LOG.info('Writing:  "%s"', log_file)
+        hash_sums[base_path] = hash
+        LOG.info('File Hash:  "%s" into "%s"', hash_sums, target_path)
+        #TODO: Test without changing directory
         os.chdir(target_log_path)
         file_out = open(log_file, "a")
         for key,value in hash_sums.items():

--- a/promenade/renderer.py
+++ b/promenade/renderer.py
@@ -2,6 +2,7 @@ from . import logging
 import jinja2
 import os
 import pkg_resources
+import hashlib
 
 __all__ = ['Renderer']
 
@@ -28,6 +29,8 @@ class Renderer:
                 source_path = os.path.join(root, source_filename)
                 self.render_template_file(path=source_path,
                                           root=source_root)
+                self.generate_sha_hashes(path=source_path,
+                                          root=source_root)
 
     def render_template_file(self, *, path, root):
         base_path = os.path.relpath(path, root)
@@ -47,6 +50,32 @@ class Renderer:
             f.write(rendered_data)
 
         LOG.info('Installed "%s"', os.path.join('/', base_path))
+
+    def generate_sha_hashes(self, *, path, root):
+        base_path = os.path.relpath(path, root)
+        target_path = os.path.join(self.target_dir, base_path)
+        log_path = "var/log/promenade/"
+        LOG.info('VARIABLE REVEAL: self.target_dir is:"%s" and base_path is: "%s" and target_path is "%s"', self.target_dir, base_path, target_path)
+        target_log_path = os.path.join(self.target_dir, log_path)
+        log_file = os.path.join(target_log_path, "modified_file_check.txt")
+        try:
+            LOG.debug('Creating "%s"', target_log_path)
+            os.mkdir(target_log_path)
+        except OSError:
+            LOG.debug('Skipping creation of "%s" because it already exists', target_log_path)
+
+        hash_sums = {}
+        hash = hashlib.sha256(open(path,'rb').read()).hexdigest()
+        hash_sums[target_path] = hash
+        #os.chdir(log_path)
+        LOG.info('HASHING:  "%s" into "%s"', hash_sums, target_path)
+        LOG.info('Writing:  "%s"', log_file)
+        os.chdir(target_log_path)
+        file_out = open(log_file, "a")
+        for key,value in hash_sums.items():
+            output = key + ": " + value
+            file_out.write(output + "\n")
+        file_out.close()
 
 
 def _ensure_path(path):

--- a/promenade/renderer.py
+++ b/promenade/renderer.py
@@ -65,14 +65,14 @@ class Renderer:
             LOG.info('Skipping creation of "%s" because it already exists', target_log_path)
 #Generate Hashes and Write to file
         hash_sums = {}
-        hash = hashlib.sha256(open(path,'rb').read()).hexdigest()
+        hash = hashlib.sha256(open(target_path,'rb').read()).hexdigest()
         hash_sums[base_path] = hash
-        LOG.info('File Hash:  "%s" into "%s"', hash_sums, target_path)
+        LOG.info('File Hash:  "%s" into "%s"', hash_sums, os.path.join('/', base_path))
         #TODO: Test without changing directory
         os.chdir(target_log_path)
         file_out = open(log_file, "a")
         for key,value in hash_sums.items():
-            output = key + ": " + value
+            output = os.path.join('/', key) + ": " + value
             file_out.write(output + "\n")
         file_out.close()
 


### PR DESCRIPTION
This PR is a work in progress to address the need for host validation of files generated by Promenade.  This initial takes a SHA256 hash of all promenade generated files and writes them to `/var/log/promenade/promenade_file_hash.log` -- Next step will be running validation calls to ensure the files have not changed. 