### PR TITLE
Shorten apply sleeps

### DIFF
--- a/promenade/templates/genesis/etc/kubernetes/kubelet/manifests/armada-loader.yaml
+++ b/promenade/templates/genesis/etc/kubernetes/kubelet/manifests/armada-loader.yaml
@@ -24,7 +24,7 @@ spec:
               cp /etc/kubernetes/armada-loader/kubeconfig.yaml /root/.kube/config
 
               while true; do
-                sleep 60
+                sleep 10
                 if armada apply promenade-armada.yaml ; then
                   break
                 fi

--- a/promenade/templates/genesis/etc/kubernetes/kubelet/manifests/asset-loader.yaml
+++ b/promenade/templates/genesis/etc/kubernetes/kubelet/manifests/asset-loader.yaml
@@ -19,7 +19,7 @@ spec:
         - |-
             set -x
             while true; do
-              sleep 60
+              sleep 10
               /kubectl \
                 --kubeconfig /etc/kubernetes/asset-loader/kubeconfig.yaml \
                 apply -f /etc/kubernetes/asset-loader/assets


### PR DESCRIPTION
These delays are needlessly large.  It can shorten the process by a minute or two to make these delays smaller.