### PR TITLE
Remove NTP package

### DIFF
--- a/promenade/templates/common/usr/local/bin/bootstrap
+++ b/promenade/templates/common/usr/local/bin/bootstrap
@@ -9,6 +9,8 @@ apt-get install -y --no-install-recommends \
     dnsmasq \
     socat
 
+apt-get remove -y chrony ntp
+
 systemctl daemon-reload
 systemctl enable kubelet
 systemctl restart kubelet


### PR DESCRIPTION
If NTP is running, it will conflict with the MaaS rack controller's
NTP process.  This prevents the rack controller from functioning.