### PR TITLE
Enable kubernetes cron-jobs

### DIFF
--- a/promenade/templates/master/etc/kubernetes/kubelet/manifests/kube-apiserver.yaml
+++ b/promenade/templates/master/etc/kubernetes/kubelet/manifests/kube-apiserver.yaml
@@ -24,6 +24,7 @@ spec:
         - --client-ca-file=/etc/kubernetes/pki/cluster-ca.pem
         - --insecure-port=0
         - --bind-address=0.0.0.0
+        - --runtime-config=batch/v2alpha1=true
         - --secure-port=443
         - --allow-privileged=true
         - --etcd-servers=https://kubernetes:2379


### PR DESCRIPTION
I didn't make this configurable, as it's not precisely clear where this kind of direct kubernetes configuration should live yet.

Also, we might want to enable all apis instead/for now.